### PR TITLE
Respect original remember-me cookie on impersonator's login after impersonation stops

### DIFF
--- a/src/Impersonator.php
+++ b/src/Impersonator.php
@@ -173,12 +173,7 @@ class Impersonator
 
         $remember = false;
         if ($recaller instanceof Recaller && $recaller->valid()) {
-            $recallerId = $recaller->id();
-            if (is_int($impersonatorId)) {
-                $recallerId = intval($recallerId);
-            }
-
-            $remember = $impersonatorId === $recallerId;
+            $remember = $impersonatorId == $recaller->id();
         }
 
         $guard->loginUsingId($impersonatorId, $remember);

--- a/src/Impersonator.php
+++ b/src/Impersonator.php
@@ -3,8 +3,11 @@
 namespace Mirror;
 
 use Illuminate\Auth\AuthManager;
+use Illuminate\Auth\Recaller;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use InvalidArgumentException;
@@ -158,13 +161,27 @@ class Impersonator
         $guardName = $session->getGuardName();
 
         $guard = $this->auth->guard($guardName);
+
+        $recaller = $this->recaller($guard);
+
         /** @var Authenticatable $impersonatedUser */
         $impersonatedUser = $guard->user();
 
         $session->clear();
 
         $guard->logout();
-        $guard->loginUsingId($impersonatorId);
+
+        $remember = false;
+        if ($recaller instanceof Recaller && $recaller->valid()) {
+            $recallerId = $recaller->id();
+            if (is_int($impersonatorId)) {
+                $recallerId = intval($recallerId);
+            }
+
+            $remember = $impersonatorId === $recallerId;
+        }
+
+        $guard->loginUsingId($impersonatorId, $remember);
 
         /** @var Authenticatable $impersonatorUser */
         $impersonatorUser = $guard->user();
@@ -426,5 +443,25 @@ class Impersonator
         if (is_object($result) && method_exists($result, 'afterResponse')) {
             $result->afterResponse();
         }
+    }
+
+    /**
+     * Get the decrypted recaller cookie for the request.
+     */
+    protected function recaller(Guard|StatefulGuard $guard): ?Recaller
+    {
+        if (
+            ! is_callable([$guard, 'getRequest'])
+            || ! is_callable([$guard, 'getRecallerName'])
+            || is_null($guard->getRequest())
+        ) {
+            return null;
+        }
+
+        if ($recaller = $guard->getRequest()->cookies->get($guard->getRecallerName())) {
+            return new Recaller($recaller);
+        }
+
+        return null;
     }
 }

--- a/tests/Feature/ImpersonatorTest.php
+++ b/tests/Feature/ImpersonatorTest.php
@@ -3,10 +3,12 @@
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Events\Dispatcher as EventsDispatcher;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
 use Mirror\Events\ImpersonationStarted;
 use Mirror\Events\ImpersonationStopped;
@@ -887,4 +889,70 @@ it('isImpersonating can be called many times with minimal session reads', functi
 
     expect(array_unique($checks))->toHaveCount(1)
         ->and($checks[0])->toBeTrue();
+});
+
+it('remembers the "remember" cookie of the impersonator\'s original session', function (): void {
+    $admin = User::factory()->create();
+    $targetUser = User::factory()->create();
+
+    // Create route so we can check the cookies
+    Route::post('/stop', function (): Response {
+        Mirror::stop();
+        $guard = Auth::guard('web');
+
+        expect($guard->getCookieJar()->hasQueued($guard->getRecallerName()))
+            ->toBeTrue();
+
+        return response('ok');
+    });
+
+    $guard = Auth::guard('web');
+    $remember = true;
+    $guard->login($admin, $remember);
+
+    Mirror::start($targetUser);
+
+    expect(Auth::id())->toBe($targetUser->id)
+        ->and(Mirror::isImpersonating())->toBeTrue()
+        ->and(Mirror::impersonatorId())->toBe($admin->id);
+
+    $cookies = [
+        $guard->getRecallerName() => $admin->getAuthIdentifier().'|'.$admin->getRememberToken().'|'.$admin->getAuthPassword(),
+    ];
+
+    $this->actingAs($targetUser, 'web')->call('POST', '/stop', [], $cookies);
+    expect(Auth::id())->toBe($admin->id)
+        ->and(Mirror::isImpersonating())->toBeFalse();
+
+});
+
+it('doesnt set the "remember" cookie if the impersonator\'s original session didnt have it', function (): void {
+    $admin = User::factory()->create();
+    $targetUser = User::factory()->create();
+
+    // Create route so we can check the cookies
+    Route::post('/stop', function (): Response {
+        Mirror::stop();
+        $guard = Auth::guard('web');
+
+        expect($guard->getCookieJar()->hasQueued($guard->getRecallerName()))
+            ->toBeFalse();
+
+        return response('ok');
+    });
+
+    $guard = Auth::guard('web');
+    $guard->login($admin);
+
+    Mirror::start($targetUser);
+
+    expect(Auth::id())->toBe($targetUser->id)
+        ->and(Mirror::isImpersonating())->toBeTrue()
+        ->and(Mirror::impersonatorId())->toBe($admin->id);
+
+    $this->actingAs($targetUser, 'web')->post('/stop');
+
+    expect(Auth::id())->toBe($admin->id)
+        ->and(Mirror::isImpersonating())->toBeFalse();
+
 });


### PR DESCRIPTION
It fixes #6.

Right now phpstan is complaining that:

> Call to function is_callable() with array{Illuminate\Contracts\Auth\Guard, 'getRequest'} will always evaluate to true.

but afaics the contract does not include a `getRequest()` method, which is why I included the checks.

Not sure how to fix it.